### PR TITLE
Prepare new test scenario for RHEL-1382 and RHEL-59170

### DIFF
--- a/Regression/rhel-1382_rhel-59170/main.fmf
+++ b/Regression/rhel-1382_rhel-59170/main.fmf
@@ -1,0 +1,21 @@
+summary: RHEL-1382 and RHEL-59170 regression test
+description: ''
+contact: Patrik Koncity <pkoncity@redhat.com>
+component:
+  - aide
+test: ./runtest.sh
+require+:
+  - aide
+duration: 5m
+enabled: true
+tag:
+  - NoRHEL6
+  - NoRHEL7
+  - NoRHEL8
+link:
+  - verifies: https://issues.redhat.com/browse/RHEL-1382
+  - verifies: https://issues.redhat.com/browse/RHEL-59170
+adjust:
+  - enabled: false
+    when: distro < rhel-9.8
+    continue: false

--- a/Regression/rhel-1382_rhel-59170/runtest.sh
+++ b/Regression/rhel-1382_rhel-59170/runtest.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /Regression/rhel-1382_rhel-59170
+#   Author: Patrik Koncity <pkoncity@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2025 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+
+rlJournalStart
+    rlPhaseStartSetup
+        AIDE_TEST_DIR=/var/aide-testing-dir/
+        rlRun "mkdir -p /var/aide-testing-dir"
+        pushd $AIDE_TEST_DIR
+        rlLog "Test directory created and working inside: $AIDE_TEST_DIR"
+        rlLog "Copying and adjusting /etc/aide.conf"
+        rlRun "cp /etc/aide.conf ."
+        rlRun "sed -i 's#^@@define DBDIR.*#@@define DBDIR /var/aide-testing-dir#' aide.conf"
+        rlRun "sed -i 's#^@@define LOGDIR.*#@@define LOGDIR /var/aide-testing-dir#' aide.conf"
+        rlRun "sed -i '/^# Next decide what directories\/files you want in the database./,\$d' aide.conf"
+        rlRun "echo -e '!/run d\n/run R' | tee -a aide.conf"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Check aide --init correctly measure files and not containing any warnings"
+        rlLog "Initializing AIDE database locally..."
+        rlRun -s "aide --config=aide.conf --init" 0 "AIDE initialization"
+        if rlIsRHELLike ">10.1" ; then
+            rlAssertNotGrep "WARNING: /var/aide-testing-dir/aide.db.new.gz: gnutls_hash_init (stribog256) failed for '/var/aide-testing-dir/aide.db.new.gz'" $rlRun_LOG
+            rlAssertNotGrep "WARNING: /var/aide-testing-dir/aide.db.new.gz: gnutls_hash_init (stribog512) failed for '/var/aide-testing-dir/aide.db.new.gz'" $rlRun_LOG
+        fi
+        rlAssertNotGrep "Number of entries:	0" $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlLog "Cleaning up..."
+        popd
+        rlRun "rm -rf $AIDE_TEST_DIR" 0 "Removing temporary directory"
+    rlPhaseEnd
+
+rlJournalPrintText
+rlJournalEnd


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new regression test scenario for RHEL-1382 and RHEL-59170 that sets up an isolated AIDE environment, runs ʻaide --initʼ, and verifies the absence of stribog-related warnings and a non-zero entry count, with cleanup and FMF metadata.

New Features:
- Add a BeakerLib test script (runtest.sh) to configure and initialize AIDE in /var/aide-testing-dir
- Include a main.fmf file to define the new test scenario

Tests:
- Assert that no gnutls_hash_init warnings for stribog256/512 appear on RHEL-like systems >10.1
- Assert that the initialized AIDE database contains more than zero entries