### PR TITLE
Add issue link to .fmf metadata

### DIFF
--- a/Regression/rhel-76014-http-link-as-database/main.fmf
+++ b/Regression/rhel-76014-http-link-as-database/main.fmf
@@ -10,6 +10,8 @@ require+:
   - python3
 duration: 5m
 enabled: true
+link:
+  - verifies: https://issues.redhat.com/browse/RHEL-76014
 adjust+:
   - enabled: false
     when: distro < rhel-9.8


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add an 'issue' field to the .fmf metadata of the rhel-76014-http-link-as-database regression test to reference the related bug