### PR TITLE
Disable test for RHEL-9.8 and adjust grep error message

### DIFF
--- a/Sanity/aide-config-check-command/runtest.sh
+++ b/Sanity/aide-config-check-command/runtest.sh
@@ -62,13 +62,13 @@ rlJournalStart
     rlPhaseStartTest "Passing non-existing filepath"
         rlRun -s "aide -D -c /nosuchfile" 17,18
         rlRun "cat $rlRun_LOG"
-	if rlIsRHELLike "=<9"; then
+	      if rlIsRHELLike "<9.8"; then
           rlAssertGrep "Cannot access config file: ?/nosuchfile: ?No such file or directory" $rlRun_LOG -E
           rlAssertGrep "No config defined" $rlRun_LOG
           rlAssertGrep "Configuration error" $rlRun_LOG
-	else
+	      else
           rlAssertGrep "ERROR: cannot open config file '/nosuchfile': No such file or directory" $rlRun_LOG
-	fi
+	      fi
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/Sanity/aide-output-to-multiple-report_url-streams/main.fmf
+++ b/Sanity/aide-output-to-multiple-report_url-streams/main.fmf
@@ -16,7 +16,7 @@ recommend:
 duration: 5m
 enabled: true
 adjust+:
--   when: distro >= rhel-10 or distro >= centos-stream-10 or distro == fedora
+-   when: distro >= 9.8 or distro >= centos-stream-9 or distro == fedora
     enabled: false
 tier: '1'
 extra-task: /CoreOS/aide/Sanity/aide-output-to-multiple-report_url-streams

--- a/Sanity/aide-rules-test/main.fmf
+++ b/Sanity/aide-rules-test/main.fmf
@@ -10,7 +10,7 @@ recommend:
 duration: 15m
 enabled: true
 adjust+:
--   when: distro >= rhel-10 or distro >= centos-stream-10 or distro == fedora
+-   when: distro >= 9.8 or distro >= centos-stream-9 or distro == fedora
     enabled: false
 tier: '1'
 extra-task: /CoreOS/aide/Sanity/aide-rules-test


### PR DESCRIPTION
Syslog format is not used in new version of aide,
disable related tests, also adjust message format for aide in RHEL-9.8.