### PR TITLE
Fixed issue with CUT when upgrading from RHEL 8 to RHEL 9

### DIFF
--- a/Sanity/aide-check-sanity/runtest.sh
+++ b/Sanity/aide-check-sanity/runtest.sh
@@ -40,43 +40,33 @@ rlJournalStart && {
     if rlIsRHELLike "=<9.7"; then
       AIDE_CONF=aide_rhel_9.conf
     fi
-    if [[ "${IN_PLACE_UPGRADE,,}" == "new" ]]; then
-        if rlIsRHELLike ">=10"; then
-          rlRun "mv $AIDE_CONF $AIDE_TEST_DIR/aide.conf"
-        fi
-        if rlIsRHELLike "=<9"; then
-            rlRun "mv $AIDE_CONF $AIDE_TEST_DIR/aide.conf"
-        fi
-    fi
     [[ "${IN_PLACE_UPGRADE,,}" != "new" ]] && {
       rlRun "rlFileBackup --clean $AIDE_TEST_DIR"
-      rlRun "mkdir -p $AIDE_TEST_DIR/{,data,db,log}"
-      rlRun "mv $AIDE_CONF $AIDE_TEST_DIR/aide.conf"
-      rlRun "touch $AIDE_TEST_DIR/data/empty_file"
-      rlRun "echo 'x' > $AIDE_TEST_DIR/data/file1"
-      rlRun "echo 'y' > $AIDE_TEST_DIR/data/file2"
-      rlRun "echo 'z' > $AIDE_TEST_DIR/data/file3"
-      rlRun "chmod a=rw $AIDE_TEST_DIR/data/*"
-      rlRun "aide -i -c $AIDE_TEST_DIR/aide.conf"
-      rlRun "mv -f $AIDE_TEST_DIR/db/aide.db.out.gz $AIDE_TEST_DIR/db/aide.db.gz"
-      rlRun "echo 'A' > $AIDE_TEST_DIR/data/file4"
-      rlRun "rm -f $AIDE_TEST_DIR/data/file1"
-      rlRun "echo 'B' > $AIDE_TEST_DIR/data/file2"
-      rlRun "chmod a+x $AIDE_TEST_DIR/data/file3"
     }
+    rlRun "rm -rf $AIDE_TEST_DIR"
+    rlRun "mkdir -p $AIDE_TEST_DIR/{,data,db,log}"
+    rlRun "mv $AIDE_CONF $AIDE_TEST_DIR/aide.conf"
+    rlRun "touch $AIDE_TEST_DIR/data/empty_file"
+    rlRun "echo 'x' > $AIDE_TEST_DIR/data/file1"
+    rlRun "echo 'y' > $AIDE_TEST_DIR/data/file2"
+    rlRun "echo 'z' > $AIDE_TEST_DIR/data/file3"
+    rlRun "chmod a=rw $AIDE_TEST_DIR/data/*"
+    rlRun "aide -i -c $AIDE_TEST_DIR/aide.conf"
+    rlRun "mv -f $AIDE_TEST_DIR/db/aide.db.out.gz $AIDE_TEST_DIR/db/aide.db.gz"
+    rlRun "echo 'A' > $AIDE_TEST_DIR/data/file4"
+    rlRun "rm -f $AIDE_TEST_DIR/data/file1"
+    rlRun "echo 'B' > $AIDE_TEST_DIR/data/file2"
+    rlRun "chmod a+x $AIDE_TEST_DIR/data/file3"
   rlPhaseEnd; }
 
   rlPhaseStartTest "aide check" && {
-    bash
     rlRun -s "aide --check -c $AIDE_TEST_DIR/aide.conf" 0-255
-    bash
     if rlIsRHELLike "<9.8" ; then
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file1; removed" $rlRun_LOG
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file2;SHA256_old=O7Krtp67J/v+Y8djliTG7F4zG4QaW8jD68ELkoXpCHc=;SHA256_new=wM3nf6j++X1HbBCq09LVT8wvM2FA0HNlHC3Mzx43n9Y=" $rlRun_LOG
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file3;Perm_old=-rw-rw-rw-;Perm_new=-rwxrwxrwx" $rlRun_LOG
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file4; added" $rlRun_LOG
     elif rlIsFedora ">41" || rlIsRHELLike '>=9.8'; then
-    bash
       rlAssertGrep "f-----------------: /var/aide-testing-dir/data/file1" $rlRun_LOG
       rlAssertGrep "File: $AIDE_TEST_DIR/data/file2\n
  SHA256    : O7Krtp67J/v+Y8djliTG7F4zG4QaW8jD | wM3nf6j++X1HbBCq09LVT8wvM2FA0HNl\n

--- a/Sanity/aide-check-sanity/runtest.sh
+++ b/Sanity/aide-check-sanity/runtest.sh
@@ -74,13 +74,16 @@ rlJournalStart && {
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file3;Perm_old=-rw-rw-rw-;Perm_new=-rwxrwxrwx" $rlRun_LOG
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file4; added" $rlRun_LOG
     elif rlIsFedora ">41" || rlIsRHELLike '>=9.8'; then
+    bash
     cat /var/aide-testing-dir/data/file1
       rlAssertGrep "f-----------------: /var/aide-testing-dir/data/file1" $rlRun_LOG
+      bash
       cat /var/aide-testing-dir/data/file2
       rlAssertGrep "File: $AIDE_TEST_DIR/data/file2\n
  SHA256    : O7Krtp67J/v+Y8djliTG7F4zG4QaW8jD | wM3nf6j++X1HbBCq09LVT8wvM2FA0HNl\n
              68ELkoXpCHc=                     | HC3Mzx43n9Y=" $rlRun_LOG
-             cat
+             rlRun "bash"
+             rlRun "cat /var/aide-testing-dir/data/file3"
       rlAssertGrep "File: $AIDE_TEST_DIR/data/file3\n
  Perm      : -rw-rw-rw-                       | -rwxrwxrwx" $rlRun_LOG
  cat /var/aide-testing-dir/data/file4

--- a/Sanity/aide-check-sanity/runtest.sh
+++ b/Sanity/aide-check-sanity/runtest.sh
@@ -40,23 +40,30 @@ rlJournalStart && {
     if rlIsRHELLike "=<9.7"; then
       AIDE_CONF=aide_rhel_9.conf
     fi
+    if [[ "${IN_PLACE_UPGRADE,,}" == "new" ]]; then
+        if rlIsRHELLike ">=10"; then
+          rlRun "mv $AIDE_CONF $AIDE_TEST_DIR/aide.conf"
+        fi
+        if rlIsRHELLike "=<9"; then
+            rlRun "mv $AIDE_CONF $AIDE_TEST_DIR/aide.conf"
+        fi
+    fi
     [[ "${IN_PLACE_UPGRADE,,}" != "new" ]] && {
       rlRun "rlFileBackup --clean $AIDE_TEST_DIR"
+      rlRun "mkdir -p $AIDE_TEST_DIR/{,data,db,log}"
+      rlRun "mv $AIDE_CONF $AIDE_TEST_DIR/aide.conf"
+      rlRun "touch $AIDE_TEST_DIR/data/empty_file"
+      rlRun "echo 'x' > $AIDE_TEST_DIR/data/file1"
+      rlRun "echo 'y' > $AIDE_TEST_DIR/data/file2"
+      rlRun "echo 'z' > $AIDE_TEST_DIR/data/file3"
+      rlRun "chmod a=rw $AIDE_TEST_DIR/data/*"
+      rlRun "aide -i -c $AIDE_TEST_DIR/aide.conf"
+      rlRun "mv -f $AIDE_TEST_DIR/db/aide.db.out.gz $AIDE_TEST_DIR/db/aide.db.gz"
+      rlRun "echo 'A' > $AIDE_TEST_DIR/data/file4"
+      rlRun "rm -f $AIDE_TEST_DIR/data/file1"
+      rlRun "echo 'B' > $AIDE_TEST_DIR/data/file2"
+      rlRun "chmod a+x $AIDE_TEST_DIR/data/file3"
     }
-    rlRun "rm -rf $AIDE_TEST_DIR"
-    rlRun "mkdir -p $AIDE_TEST_DIR/{,data,db,log}"
-    rlRun "mv $AIDE_CONF $AIDE_TEST_DIR/aide.conf"
-    rlRun "touch $AIDE_TEST_DIR/data/empty_file"
-    rlRun "echo 'x' > $AIDE_TEST_DIR/data/file1"
-    rlRun "echo 'y' > $AIDE_TEST_DIR/data/file2"
-    rlRun "echo 'z' > $AIDE_TEST_DIR/data/file3"
-    rlRun "chmod a=rw $AIDE_TEST_DIR/data/*"
-    rlRun "aide -i -c $AIDE_TEST_DIR/aide.conf"
-    rlRun "mv -f $AIDE_TEST_DIR/db/aide.db.out.gz $AIDE_TEST_DIR/db/aide.db.gz"
-    rlRun "echo 'A' > $AIDE_TEST_DIR/data/file4"
-    rlRun "rm -f $AIDE_TEST_DIR/data/file1"
-    rlRun "echo 'B' > $AIDE_TEST_DIR/data/file2"
-    rlRun "chmod a+x $AIDE_TEST_DIR/data/file3"
   rlPhaseEnd; }
 
   rlPhaseStartTest "aide check" && {
@@ -67,12 +74,16 @@ rlJournalStart && {
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file3;Perm_old=-rw-rw-rw-;Perm_new=-rwxrwxrwx" $rlRun_LOG
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file4; added" $rlRun_LOG
     elif rlIsFedora ">41" || rlIsRHELLike '>=9.8'; then
+    cat /var/aide-testing-dir/data/file1
       rlAssertGrep "f-----------------: /var/aide-testing-dir/data/file1" $rlRun_LOG
+      cat /var/aide-testing-dir/data/file2
       rlAssertGrep "File: $AIDE_TEST_DIR/data/file2\n
  SHA256    : O7Krtp67J/v+Y8djliTG7F4zG4QaW8jD | wM3nf6j++X1HbBCq09LVT8wvM2FA0HNl\n
              68ELkoXpCHc=                     | HC3Mzx43n9Y=" $rlRun_LOG
+             cat
       rlAssertGrep "File: $AIDE_TEST_DIR/data/file3\n
  Perm      : -rw-rw-rw-                       | -rwxrwxrwx" $rlRun_LOG
+ cat /var/aide-testing-dir/data/file4
       rlAssertGrep "f+++++++++++++++++: $AIDE_TEST_DIR/data/file4" $rlRun_LOG
     else
       rlAssertGrep "f----------------: $AIDE_TEST_DIR/data/file1" $rlRun_LOG

--- a/Sanity/aide-check-sanity/runtest.sh
+++ b/Sanity/aide-check-sanity/runtest.sh
@@ -67,13 +67,16 @@ rlJournalStart && {
   rlPhaseEnd; }
 
   rlPhaseStartTest "aide check" && {
+    bash
     rlRun -s "aide --check -c $AIDE_TEST_DIR/aide.conf" 0-255
+    bash
     if rlIsRHELLike "<9.8" ; then
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file1; removed" $rlRun_LOG
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file2;SHA256_old=O7Krtp67J/v+Y8djliTG7F4zG4QaW8jD68ELkoXpCHc=;SHA256_new=wM3nf6j++X1HbBCq09LVT8wvM2FA0HNlHC3Mzx43n9Y=" $rlRun_LOG
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file3;Perm_old=-rw-rw-rw-;Perm_new=-rwxrwxrwx" $rlRun_LOG
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file4; added" $rlRun_LOG
     elif rlIsFedora ">41" || rlIsRHELLike '>=9.8'; then
+    bash
       rlAssertGrep "f-----------------: /var/aide-testing-dir/data/file1" $rlRun_LOG
       rlAssertGrep "File: $AIDE_TEST_DIR/data/file2\n
  SHA256    : O7Krtp67J/v+Y8djliTG7F4zG4QaW8jD | wM3nf6j++X1HbBCq09LVT8wvM2FA0HNl\n

--- a/Sanity/aide-check-sanity/runtest.sh
+++ b/Sanity/aide-check-sanity/runtest.sh
@@ -46,6 +46,11 @@ rlJournalStart && {
         fi
         if rlIsRHELLike "=<9"; then
             rlRun "mv $AIDE_CONF $AIDE_TEST_DIR/aide.conf"
+            rlLog "(adding @@end_db)"
+            rlRun "zcat $AIDE_TEST_DIR/db/aide.db.gz > /tmp/aide.db.tmp"
+            rlRun "echo '@@end_db' >> /tmp/aide.db.tmp"
+            rlRun "gzip -c /tmp/aide.db.tmp > $AIDE_TEST_DIR/db/aide.db.gz"
+            rlRun "rm -f /tmp/aide.db.tmp"
         fi
     fi
     [[ "${IN_PLACE_UPGRADE,,}" != "new" ]] && {
@@ -74,19 +79,12 @@ rlJournalStart && {
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file3;Perm_old=-rw-rw-rw-;Perm_new=-rwxrwxrwx" $rlRun_LOG
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file4; added" $rlRun_LOG
     elif rlIsFedora ">41" || rlIsRHELLike '>=9.8'; then
-    bash
-    cat /var/aide-testing-dir/data/file1
       rlAssertGrep "f-----------------: /var/aide-testing-dir/data/file1" $rlRun_LOG
-      bash
-      cat /var/aide-testing-dir/data/file2
       rlAssertGrep "File: $AIDE_TEST_DIR/data/file2\n
  SHA256    : O7Krtp67J/v+Y8djliTG7F4zG4QaW8jD | wM3nf6j++X1HbBCq09LVT8wvM2FA0HNl\n
              68ELkoXpCHc=                     | HC3Mzx43n9Y=" $rlRun_LOG
-             rlRun "bash"
-             rlRun "cat /var/aide-testing-dir/data/file3"
       rlAssertGrep "File: $AIDE_TEST_DIR/data/file3\n
  Perm      : -rw-rw-rw-                       | -rwxrwxrwx" $rlRun_LOG
- cat /var/aide-testing-dir/data/file4
       rlAssertGrep "f+++++++++++++++++: $AIDE_TEST_DIR/data/file4" $rlRun_LOG
     else
       rlAssertGrep "f----------------: $AIDE_TEST_DIR/data/file1" $rlRun_LOG


### PR DESCRIPTION
The "new" phase of the upgrade test skipped database initialization and cleanup, causing incompatibility issues.
https://artifacts.osci.redhat.com/testing-farm/c101e1c9-94cb-4046-ba5c-2219762de08e/

## Summary by Sourcery

Bug Fixes:
- Fix missing database initialization and cleanup in the "new" phase of in-place upgrade tests by unifying AIDE test directory setup.