### PR TITLE
Add fips tag to FIPS-relevant tests

### DIFF
--- a/Regression/rhel-1382_rhel-59170/main.fmf
+++ b/Regression/rhel-1382_rhel-59170/main.fmf
@@ -9,6 +9,7 @@ require+:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - NoRHEL6
   - NoRHEL7
   - NoRHEL8

--- a/Sanity/aide-check-exit-codes/main.fmf
+++ b/Sanity/aide-check-exit-codes/main.fmf
@@ -7,6 +7,7 @@ recommend:
 duration: 15m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/aide-check-sanity/main.fmf
+++ b/Sanity/aide-check-sanity/main.fmf
@@ -6,6 +6,7 @@ require+:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - Tier1
   - ImageMode

--- a/Sanity/aide-conf-group-definition/main.fmf
+++ b/Sanity/aide-conf-group-definition/main.fmf
@@ -7,6 +7,7 @@ recommend:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/aide-conf-selection-lines/main.fmf
+++ b/Sanity/aide-conf-selection-lines/main.fmf
@@ -7,6 +7,7 @@ recommend:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/aide-config-check-command/main.fmf
+++ b/Sanity/aide-config-check-command/main.fmf
@@ -7,6 +7,7 @@ recommend:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/aide-db-update-and-compare/main.fmf
+++ b/Sanity/aide-db-update-and-compare/main.fmf
@@ -7,6 +7,7 @@ recommend:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/aide-rules-test/main.fmf
+++ b/Sanity/aide-rules-test/main.fmf
@@ -14,3 +14,5 @@ adjust+:
     enabled: false
 tier: '1'
 extra-task: /CoreOS/aide/Sanity/aide-rules-test
+tag:
+  - fips

--- a/Sanity/aide-running-as-user/main.fmf
+++ b/Sanity/aide-running-as-user/main.fmf
@@ -5,6 +5,7 @@ test: ./runtest.sh
 require+:
   - library(distribution/testUser)
 tag:
+  - fips
   - CI-Tier-1
   - Tier1
 recommend:


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Mark AIDE-related sanity and regression FMF tests with a FIPS tag for targeted execution.