### PR TITLE
Fix aide-running-as-user for /etc/aide.d drop-in directory

### DIFF
--- a/Sanity/aide-running-as-user/runtest.sh
+++ b/Sanity/aide-running-as-user/runtest.sh
@@ -48,6 +48,11 @@ rlJournalStart
         rlRun "chmod -R a=rwx $TEST_DIR/" 0 "Adding permissions for testing directory"
         rlRun "sed -i 's|@@define DBDIR .*|@@define DBDIR $TEST_DIR/db|' $TEST_DIR/aide.conf" 0
         rlRun "sed -i 's|@@define LOGDIR .*|@@define LOGDIR $TEST_DIR/log|' $TEST_DIR/aide.conf" 0
+        # Redirect @@include to a user-accessible directory (aide.d is 0700 root:root since RHEL-9.9/10.3)
+        if rlIsRHELLike ">=9.9" || rlIsRHELLike ">=10.3"; then
+            rlRun "mkdir -p -m0777 $TEST_DIR/aide.d"
+            rlRun "sed -i 's|/etc/aide\.d|${TEST_DIR}/aide.d|' $TEST_DIR/aide.conf" 0
+        fi
         rlRun "testUserSetup"
         rlRun "echo 'Random text' > $TEST_DIR/data/random.txt"
         rlRun "chmod a=r $TEST_DIR/data/random.txt"


### PR DESCRIPTION
Since RHEL-9.9/10.3, aide.conf includes @@include /etc/aide.d which has 0700 root:root permissions. When running aide as non-root user, this causes Permission denied. Redirect @@include to a user-accessible test directory on affected versions.

## Summary by Sourcery

Adjust aide-running-as-user test to handle RHEL versions where /etc/aide.d is not readable by non-root users.

Bug Fixes:
- Prevent aide-running-as-user test from failing on RHEL >= 9.9 and >= 10.3 by redirecting the /etc/aide.d include to a user-accessible directory.

Tests:
- Extend aide-running-as-user test setup to create a world-writable aide.d directory in the test sandbox and update aide.conf to include it on affected RHEL versions.