### PR TITLE
Add aide-migrate-config sanity test

### DIFF
--- a/Sanity/aide-migrate-config/legacy-aide.conf
+++ b/Sanity/aide-migrate-config/legacy-aide.conf
@@ -1,0 +1,129 @@
+# Legacy AIDE 0.16 configuration file for migration testing.
+# Based on the default /etc/aide.conf shipped with RHEL-9.4 (aide-0.16)
+# with additional user-customizable options that the migration tool must handle.
+# Paths are adjusted to monitor only the test directory.
+
+@@define DBDIR /var/aide-migrate-test/db
+@@define LOGDIR /var/aide-migrate-test/log
+
+# The location of the database to be read.
+database=file:@@{DBDIR}/aide.db.gz
+
+# The location of the database to be written.
+#database_out=sql:host:port:database:login_name:passwd:table
+#database_out=file:aide.db.new
+database_out=file:@@{DBDIR}/aide.db.new.gz
+
+# Whether to gzip the output to database
+gzip_dbout=yes
+
+# Default.
+verbose=5
+
+# Red Hat downstream option re-added via patch in 0.19.2
+syslog_format=yes
+
+# Removed config options that users may have in customized configs
+grouped=yes
+summarize_changes=yes
+ignore_list=b
+report_attributes=sha256
+
+# e2fsattrs h attribute removed in 0.18
+report_ignore_e2fsattrs=Vh
+
+report_url=file:@@{LOGDIR}/aide.log
+report_url=stdout
+#report_url=stderr
+#NOT IMPLEMENTED report_url=mailto:root@foo.com
+#NOT IMPLEMENTED report_url=syslog:LOG_AUTH
+
+# These are the default rules.
+#
+#p:      permissions
+#i:      inode:
+#n:      number of links
+#u:      user
+#g:      group
+#s:      size
+#b:      block count
+#m:      mtime
+#a:      atime
+#c:      ctime
+#S:      check for growing size
+#acl:           Access Control Lists
+#selinux        SELinux security context
+#xattrs:        Extended file attributes
+#md5:    md5 checksum
+#sha1:   sha1 checksum
+#sha256:        sha256 checksum
+#sha512:        sha512 checksum
+#rmd160: rmd160 checksum
+#tiger:  tiger checksum
+
+#haval:  haval checksum (MHASH only)
+#gost:   gost checksum (MHASH only)
+#crc32:  crc32 checksum (MHASH only)
+#whirlpool:     whirlpool checksum (MHASH only)
+
+#R:             p+i+n+u+g+s+m+c+acl+selinux+xattrs+md5
+#L:             p+i+n+u+g+acl+selinux+xattrs
+#E:             Empty group
+#>:             Growing logfile p+u+g+i+n+S+acl+selinux+xattrs
+
+# You can create custom rules like this.
+# With MHASH...
+# ALLXTRAHASHES = sha1+rmd160+sha256+sha512+whirlpool+tiger+haval+gost+crc32
+ALLXTRAHASHES = sha1+rmd160+sha256+sha512+tiger
+# Everything but access time (Ie. all changes)
+EVERYTHING = R+ALLXTRAHASHES
+
+# Group with all MHASH-only hashsums (user customization)
+MHASHGROUP = haval+crc32+crc32b+whirlpool+gost+sha256
+
+# Sane
+# NORMAL = R+sha512
+NORMAL = p+i+n+u+g+s+m+c+acl+selinux+xattrs+sha512
+
+# For directories, don't bother doing hashes
+DIR = p+i+n+u+g+acl+selinux+xattrs
+
+# Access control only
+PERMS = p+u+g+acl+selinux+xattrs
+
+# Logfile are special, in that they often change
+LOG = p+u+g+n+S+acl+selinux+xattrs
+
+# Content + file type.
+CONTENT = sha512+ftype
+
+# Extended content + file type + access.
+CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
+
+# Some files get updated automatically, so the inode/ctime/mtime change
+# but we want to know when the data inside them changes
+DATAONLY =  p+n+u+g+s+acl+selinux+xattrs+sha512
+
+# User-customized group with md5 (deprecated)
+LEGACYCHECK = p+u+g+md5
+
+# Deprecated preprocessor macros (users may have host-specific configs)
+@@ifdef CUSTOM_RULES
+CUSTOMGROUP = p+u+g+sha256
+@@endif
+
+@@ifndef DISABLE_EXTRAS
+EXTRAGROUP = p+u+g+sha512
+@@endif
+
+@@ifhost monitorhost
+HOSTGROUP = p+u+g+sha256+sha512
+@@endif
+
+@@ifnhost devhost
+NONDEVGROUP = p+u+g+sha256
+@@endif
+
+# Monitored test directories only (not the full filesystem)
+/var/aide-migrate-test/data CONTENT_EX
+/var/aide-migrate-test/log LOG

--- a/Sanity/aide-migrate-config/main.fmf
+++ b/Sanity/aide-migrate-config/main.fmf
@@ -1,0 +1,33 @@
+summary: tests aide-migrate-config migration tool from pre-0.19 config
+description: |
+    Validates that aide-migrate-config correctly migrates a legacy 0.16-style
+    configuration to 0.19.2+ syntax. Tests include:
+    - Legacy config fails aide --config-check and --init
+    - Migration tool succeeds and passes config-check
+    - Removed config options are renamed correctly
+    - Removed and deprecated hashsums are stripped
+    - Empty groups get sha256 fallback
+    - S attribute replaced with growing+s
+    - Deprecated preprocessor macros replaced
+    - e2fsattrs h attribute removed
+    - aide --init and --check succeed after migration
+    - Backup file is created
+contact: Patrik Koncity <pkoncity@redhat.com>
+test: ./runtest.sh
+require:
+  - aide
+duration: 5m
+enabled: true
+tag:
+  - CI-Tier-1
+  - Tier1
+adjust:
+  - enabled: false
+    when: distro < rhel-9.9
+    because: aide-migrate-config is available from this version
+  - enabled: false
+    when: distro < rhel-10.3 and distro >= rhel-10
+    because: aide-migrate-config is available from this version
+  - enabled: false
+    when: distro == fedora
+    because: aide-migrate-config is not shipped in Fedora

--- a/Sanity/aide-migrate-config/runtest.sh
+++ b/Sanity/aide-migrate-config/runtest.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /aide-tests/Sanity/aide-migrate-config
+#   Description: tests aide-migrate-config migration tool
+#   Author: Patrik Koncity <pkoncity@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2026 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || :
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="aide"
+TEST_DIR="/var/aide-migrate-test"
+LEGACY_CONF="legacy-aide.conf"
+
+rlJournalStart
+
+    rlPhaseStartSetup "Prepare test environment"
+        rlAssertRpm $PACKAGE
+        rlRun "which aide-migrate-config" 0 "aide-migrate-config must be available"
+        rlRun "mkdir -p $TEST_DIR/{data,db,log}"
+        rlRun "echo 'test content' > $TEST_DIR/data/testfile.txt"
+        rlRun "cp $LEGACY_CONF $TEST_DIR/aide.conf"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify --dry-run reports changes without modifying"
+        rlRun "cp $LEGACY_CONF $TEST_DIR/aide-dryrun.conf"
+        rlRun -s "aide-migrate-config --dry-run --skip-init $TEST_DIR/aide-dryrun.conf 2>&1" 0 \
+            "Dry-run must succeed"
+        rlRun "cat $rlRun_LOG" 0 "Show dry-run output"
+        rlAssertGrep "DRY-RUN mode" $rlRun_LOG
+        rlAssertGrep "would rename" $rlRun_LOG
+        rlAssertGrep "would remove hashsum" $rlRun_LOG
+        rlAssertGrep "would replace S attribute" $rlRun_LOG
+        rlAssertGrep "would replace deprecated @@ifdef" $rlRun_LOG
+        rlRun "diff $LEGACY_CONF $TEST_DIR/aide-dryrun.conf" 0 \
+            "Config must be unchanged after dry-run"
+    rlPhaseEnd
+
+    rlPhaseStartTest "aide --config-check fails with legacy config"
+        rlRun -s "aide --config-check -c $TEST_DIR/aide.conf" 17 \
+            "Legacy 0.16 config must fail config-check on aide 0.19+"
+    rlPhaseEnd
+
+    rlPhaseStartTest "aide --init fails with legacy config"
+        rlRun "aide --init -c $TEST_DIR/aide.conf" 17 \
+            "Legacy 0.16 config must fail init on aide 0.19+"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Run aide-migrate-config"
+        rlRun -s "aide-migrate-config --skip-init $TEST_DIR/aide.conf 2>&1" 0 \
+            "Migration tool must succeed"
+        rlAssertGrep "migration complete" $rlRun_LOG
+        rlAssertGrep "aide --config-check passed" $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify database= was renamed to database_in="
+        rlAssertNotGrep '^database=' $TEST_DIR/aide.conf -E
+        rlAssertGrep '^database_in=' $TEST_DIR/aide.conf -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify verbose= was replaced with log_level= and report_level="
+        rlAssertNotGrep '^verbose=' $TEST_DIR/aide.conf -E
+        rlAssertGrep '^log_level=' $TEST_DIR/aide.conf -E
+        rlAssertGrep '^report_level=' $TEST_DIR/aide.conf -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify grouped= was renamed to report_grouped="
+        rlAssertNotGrep '^grouped=' $TEST_DIR/aide.conf -E
+        rlAssertGrep '^report_grouped=' $TEST_DIR/aide.conf -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify summarize_changes= was renamed to report_summarize_changes="
+        rlAssertNotGrep '^summarize_changes=' $TEST_DIR/aide.conf -E
+        rlAssertGrep '^report_summarize_changes=' $TEST_DIR/aide.conf -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify ignore_list= was renamed to report_ignore_changed_attrs="
+        rlAssertNotGrep '^ignore_list=' $TEST_DIR/aide.conf -E
+        rlAssertGrep '^report_ignore_changed_attrs=' $TEST_DIR/aide.conf -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify report_attributes= was renamed to report_force_attrs="
+        rlAssertNotGrep '^report_attributes=' $TEST_DIR/aide.conf -E
+        rlAssertGrep '^report_force_attrs=' $TEST_DIR/aide.conf -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify syslog_format is preserved after migration"
+        rlAssertGrep '^syslog_format=yes' $TEST_DIR/aide.conf -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify e2fsattrs h was removed"
+        rlRun -s "grep 'report_ignore_e2fsattrs' $TEST_DIR/aide.conf"
+        rlAssertNotGrep 'h' $rlRun_LOG
+        rlAssertGrep 'V' $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify removed hashsums were stripped from non-comment lines"
+        rlRun -s "grep -v '^#' $TEST_DIR/aide.conf"
+        for hash in tiger haval crc32b crc32 whirlpool; do
+            rlAssertNotGrep "$hash" $rlRun_LOG
+        done
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify deprecated hashsums were stripped"
+        rlRun -s "grep '^ALLXTRAHASHES' $TEST_DIR/aide.conf"
+        rlAssertNotGrep 'sha1' $rlRun_LOG
+        rlAssertNotGrep 'rmd160' $rlRun_LOG
+        # sha256 and sha512 must remain
+        rlAssertGrep 'sha256' $rlRun_LOG
+        rlAssertGrep 'sha512' $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify md5 and gost were stripped"
+        rlRun -s "grep -v '^#' $TEST_DIR/aide.conf"
+        rlAssertNotGrep 'md5' $rlRun_LOG
+        rlAssertNotGrep 'gost' $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify MHASHGROUP kept sha256 after removal of removed/deprecated hashes"
+        rlRun -s "grep '^MHASHGROUP' $TEST_DIR/aide.conf"
+        rlAssertGrep 'sha256' $rlRun_LOG
+        rlAssertNotGrep 'haval' $rlRun_LOG
+        rlAssertNotGrep 'crc32' $rlRun_LOG
+        rlAssertNotGrep 'whirlpool' $rlRun_LOG
+        rlAssertNotGrep 'gost' $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify LEGACYCHECK md5 was replaced"
+        rlRun -s "grep '^LEGACYCHECK' $TEST_DIR/aide.conf"
+        rlAssertNotGrep 'md5' $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify S attribute was replaced with growing+s"
+        rlRun -s "grep '^LOG' $TEST_DIR/aide.conf"
+        rlAssertGrep 'growing+s' $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify deprecated macros were replaced"
+        rlAssertNotGrep '@@ifdef' $TEST_DIR/aide.conf
+        rlAssertNotGrep '@@ifndef' $TEST_DIR/aide.conf
+        rlAssertNotGrep '@@ifhost' $TEST_DIR/aide.conf
+        rlAssertNotGrep '@@ifnhost' $TEST_DIR/aide.conf
+        rlAssertGrep '@@if defined' $TEST_DIR/aide.conf
+        rlAssertGrep '@@if not defined' $TEST_DIR/aide.conf
+        rlAssertGrep '@@if hostname' $TEST_DIR/aide.conf
+        rlAssertGrep '@@if not hostname' $TEST_DIR/aide.conf
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify config-check passes after migration"
+        rlRun "aide --config-check -c $TEST_DIR/aide.conf" 0 \
+            "Migrated config must pass config-check"
+    rlPhaseEnd
+
+    rlPhaseStartTest "aide --init succeeds with migrated config"
+        rlRun "aide --init -c $TEST_DIR/aide.conf" 0 \
+            "aide --init must succeed with migrated config"
+        rlAssertExists "$TEST_DIR/db/aide.db.new.gz"
+        rlRun "mv $TEST_DIR/db/aide.db.new.gz $TEST_DIR/db/aide.db.gz"
+    rlPhaseEnd
+
+    rlPhaseStartTest "aide --check succeeds with migrated config"
+        rlRun "aide --check -c $TEST_DIR/aide.conf" 0 \
+            "aide --check must succeed with migrated config and fresh database"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Migration is idempotent"
+        rlRun -s "aide-migrate-config --skip-init $TEST_DIR/aide.conf 2>&1" 0 \
+            "Second migration run must succeed"
+        rlAssertGrep "no migration needed" $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify backup was created"
+        rlRun "ls $TEST_DIR/aide.conf.bak.*" 0 \
+            "Backup file must exist"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup "Clean up test environment"
+        rlRun "rlFileSubmit $TEST_DIR/aide.conf migrated-aide.conf" 0-1 \
+            "Submit migrated config for debugging"
+        rlRun "rm -rf $TEST_DIR"
+    rlPhaseEnd
+
+rlJournalPrintText
+rlJournalEnd


### PR DESCRIPTION
Tests the aide-migrate-config migration tool end-to-end:
- Legacy 0.16 config fails aide --config-check and --init
- Migration tool succeeds
- Verifies all breaking changes are handled: renamed config options, removed/deprecated hashsums, S attribute, deprecated preprocessor macros, e2fsattrs
- aide --init and --check succeed after migration
- Backup file is created

## Summary by Sourcery

Add an end-to-end sanity test for the aide-migrate-config tool using a legacy AIDE 0.16 configuration and verifying successful migration on modern AIDE versions.

Tests:
- Introduce a Beakerlib-based sanity test that validates aide-migrate-config migrates a legacy AIDE 0.16 config so that aide --config-check, --init, and --check succeed.
- Add a legacy AIDE 0.16 configuration fixture covering renamed options, removed and deprecated hash algorithms, S attribute handling, deprecated macros, and e2fsattrs for migration verification.
- Register the new aide-migrate-config sanity test in the test metadata.