### PR TITLE
Run aide-migrate-config in aide-check-sanity post-upgrade path

### DIFF
--- a/Sanity/aide-check-sanity/runtest.sh
+++ b/Sanity/aide-check-sanity/runtest.sh
@@ -52,6 +52,18 @@ rlJournalStart && {
             rlRun "gzip -c /tmp/aide.db.tmp > $AIDE_TEST_DIR/db/aide.db.gz"
             rlRun "rm -f /tmp/aide.db.tmp"
         fi
+        # Verify %post automatically migrated the default /etc/aide.conf
+        if command -v aide-migrate-config &>/dev/null; then
+            if [ -f /var/log/aide/aide-migrate.log ]; then
+                rlRun "cat /var/log/aide/aide-migrate.log" 0 \
+                    "Show automatic migration log from %post"
+            fi
+            rlRun "aide --config-check -c /etc/aide.conf" 0 \
+                "Default config must be valid after package upgrade"
+            # Migrate the test config to 0.19+ syntax
+            rlRun "aide-migrate-config --skip-init $AIDE_TEST_DIR/aide.conf" 0 \
+                "Migrate test config to 0.19+ syntax"
+        fi
     fi
     [[ "${IN_PLACE_UPGRADE,,}" != "new" ]] && {
       rlRun "rlFileBackup --clean $AIDE_TEST_DIR"


### PR DESCRIPTION
When IN_PLACE_UPGRADE=new, the test config may contain legacy 0.16 syntax (database=, verbose=) that AIDE 0.19+ rejects. Run aide-migrate-config on the test config if available to handle the config migration, matching the real upgrade flow where %post runs the migration on /etc/aide.conf.

Also verify that %post automatically migrated the default /etc/aide.conf by running aide --config-check and showing the migration log.

## Summary by Sourcery

Tests:
- Extend aide-check-sanity post-upgrade path to verify /etc/aide.conf passes aide --config-check and to migrate the test config to 0.19+ syntax when aide-migrate-config is available.