### PR TITLE
Move aide-migrate-config call inside rlIsRHELLike =<9 condition

### DIFF
--- a/Sanity/aide-check-sanity/runtest.sh
+++ b/Sanity/aide-check-sanity/runtest.sh
@@ -45,24 +45,26 @@ rlJournalStart && {
           rlRun "mv $AIDE_CONF $AIDE_TEST_DIR/aide.conf"
         fi
         if rlIsRHELLike "=<9"; then
+            # Verify %post automatically migrated the default /etc/aide.conf
+            if command -v aide-migrate-config &>/dev/null; then
+                if [ -f /var/log/aide/aide-migrate.log ]; then
+                    rlRun "cat /var/log/aide/aide-migrate.log" 0 \
+                        "Show automatic migration log from %post"
+                fi
+                rlRun "aide --config-check -c /etc/aide.conf" 0 \
+                    "Default config must be valid after package upgrade"
+            fi
             rlRun "mv $AIDE_CONF $AIDE_TEST_DIR/aide.conf"
             rlLog "(adding @@end_db)"
             rlRun "zcat $AIDE_TEST_DIR/db/aide.db.gz > /tmp/aide.db.tmp"
             rlRun "echo '@@end_db' >> /tmp/aide.db.tmp"
             rlRun "gzip -c /tmp/aide.db.tmp > $AIDE_TEST_DIR/db/aide.db.gz"
             rlRun "rm -f /tmp/aide.db.tmp"
-        fi
-        # Verify %post automatically migrated the default /etc/aide.conf
-        if command -v aide-migrate-config &>/dev/null; then
-            if [ -f /var/log/aide/aide-migrate.log ]; then
-                rlRun "cat /var/log/aide/aide-migrate.log" 0 \
-                    "Show automatic migration log from %post"
-            fi
-            rlRun "aide --config-check -c /etc/aide.conf" 0 \
-                "Default config must be valid after package upgrade"
             # Migrate the test config to 0.19+ syntax
-            rlRun "aide-migrate-config --skip-init $AIDE_TEST_DIR/aide.conf" 0 \
-                "Migrate test config to 0.19+ syntax"
+            if command -v aide-migrate-config &>/dev/null; then
+                rlRun "aide-migrate-config --skip-init $AIDE_TEST_DIR/aide.conf" 0 \
+                    "Migrate test config to 0.19+ syntax"
+            fi
         fi
     fi
     [[ "${IN_PLACE_UPGRADE,,}" != "new" ]] && {


### PR DESCRIPTION
The migration is only needed on RHEL <=9 upgrade path where the old aide_rhel_9.conf with legacy syntax is used. Move the %post migration log check, default config validation, and test config migration inside the existing RHEL <=9 conditional block.

## Summary by Sourcery

Gate aide configuration migration checks behind the existing RHEL <=9 conditional in the aide-check-sanity test.

Tests:
- Restrict aide %post migration log and default config validation checks to RHEL <=9 paths in the sanity test.
- Guard test configuration migration with aide-migrate-config presence and only run it on RHEL <=9.