### PR TITLE
Link a RHEL issue to metadata

### DIFF
--- a/Sanity/aide-migrate-config/main.fmf
+++ b/Sanity/aide-migrate-config/main.fmf
@@ -22,6 +22,8 @@ tag:
   - CI-Tier-1
   - Tier1
   - ImageMode
+link:
+  - verifies: https://issues.redhat.com/browse/RHEL-83776
 adjust:
   - enabled: false
     when: distro < rhel-9.9


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update aide-migrate-config sanity test metadata to reference the corresponding RHEL issue.