### PR TITLE
Disable regression test which are fix just in RHEL patches

### DIFF
--- a/Regression/Check-no-weird-lines-in-etc-aide-conf/main.fmf
+++ b/Regression/Check-no-weird-lines-in-etc-aide-conf/main.fmf
@@ -22,8 +22,8 @@ adjust:
     when: distro < rhel-9
     continue: false
   - enabled: false
-    when: distro < fedora-43
-    continue: false
+    when: distro == fedora
+    because: aide-migrate-config is not shipped in Fedora
 extra-nitrate: TC#0610996
 extra-summary: /CoreOS/aide/Regression/Check-no-weird-lines-in-etc-aide-conf
 extra-task: /CoreOS/aide/Regression/Check-no-weird-lines-in-etc-aide-conf

--- a/Regression/rhel-76014-http-link-as-database/main.fmf
+++ b/Regression/rhel-76014-http-link-as-database/main.fmf
@@ -16,3 +16,6 @@ adjust+:
   - enabled: false
     when: distro < rhel-9.8
     continue: false
+  - enabled: false
+    when: distro == fedora
+    because: patch was fixed just for RHEL, fix its not shipped in fedora


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Disable the 'Check-no-weird-lines-in-etc-aide-conf' and 'rhel-76014-http-link-as-database' regression test cases that rely on RHEL-only fixes.