### PR TITLE
Add sanity tests for drop-in config, systemd timer, and missing exit codes

### DIFF
--- a/Sanity/aide-check-exit-codes/runtest.sh
+++ b/Sanity/aide-check-exit-codes/runtest.sh
@@ -119,6 +119,65 @@ rlJournalStart
         rlRun "rm ${testingFile}"
     rlPhaseEnd
 
+    rlPhaseStartTest "Checking exit code 3 (added + removed files detected)"
+        rlRun "testingFileA=\$(mktemp --tmpdir=$AIDE_TEST_DIR)" 0 "Add file A to watch dir"
+        aideInit
+        aideCheck
+
+        rlRun "testingFileB=\$(mktemp --tmpdir=$AIDE_TEST_DIR)" 0 "Add file B - will be new since last init"
+        rlRun "rm ${testingFileA}" 0 "Remove file A - was in database"
+        rlRun -s "aide" 3 "Recheck -- one added, one removed"
+        rlAssertGrep "found differences between database and filesystem" $rlRun_LOG
+        rlRun "rm $rlRun_LOG"
+
+        rlRun "rm ${testingFileB}"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Checking exit code 5 (added + changed files detected)"
+        rlRun "testingFileA=\$(mktemp --tmpdir=$AIDE_TEST_DIR)" 0 "Add file A to watch dir"
+        aideInit
+        aideCheck
+
+        rlRun "testingFileB=\$(mktemp --tmpdir=$AIDE_TEST_DIR)" 0 "Add file B - will be new since last init"
+        rlRun "echo 'test data' > ${testingFileA}" 0 "Modify file A - was in database"
+        rlRun -s "aide" 5 "Recheck -- one added, one changed"
+        rlAssertGrep "found differences between database and filesystem" $rlRun_LOG
+        rlRun "rm $rlRun_LOG"
+
+        rlRun "rm ${testingFileA} ${testingFileB}"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Checking exit code 6 (removed + changed files detected)"
+        rlRun "testingFileA=\$(mktemp --tmpdir=$AIDE_TEST_DIR)" 0 "Add file A to watch dir"
+        rlRun "testingFileB=\$(mktemp --tmpdir=$AIDE_TEST_DIR)" 0 "Add file B to watch dir"
+        aideInit
+        aideCheck
+
+        rlRun "rm ${testingFileA}" 0 "Remove file A - was in database"
+        rlRun "echo 'test data' > ${testingFileB}" 0 "Modify file B - was in database"
+        rlRun -s "aide" 6 "Recheck -- one removed, one changed"
+        rlAssertGrep "found differences between database and filesystem" $rlRun_LOG
+        rlRun "rm $rlRun_LOG"
+
+        rlRun "rm ${testingFileB}"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Checking exit code 7 (added + removed + changed files detected)"
+        rlRun "testingFileA=\$(mktemp --tmpdir=$AIDE_TEST_DIR)" 0 "Add file A to watch dir"
+        rlRun "testingFileB=\$(mktemp --tmpdir=$AIDE_TEST_DIR)" 0 "Add file B to watch dir"
+        aideInit
+        aideCheck
+
+        rlRun "testingFileC=\$(mktemp --tmpdir=$AIDE_TEST_DIR)" 0 "Add file C - will be new since last init"
+        rlRun "rm ${testingFileA}" 0 "Remove file A - was in database"
+        rlRun "echo 'test data' > ${testingFileB}" 0 "Modify file B - was in database"
+        rlRun -s "aide" 7 "Recheck -- one added, one removed, one changed"
+        rlAssertGrep "found differences between database and filesystem" $rlRun_LOG
+        rlRun "rm $rlRun_LOG"
+
+        rlRun "rm ${testingFileB} ${testingFileC}"
+    rlPhaseEnd
+
     rlPhaseStartTest "Checking exit code 15 (Invalid argument error)"
         rlRun "aide blahblah" 15
     rlPhaseEnd

--- a/Sanity/aide-check-exit-codes/runtest.sh
+++ b/Sanity/aide-check-exit-codes/runtest.sh
@@ -119,6 +119,7 @@ rlJournalStart
         rlRun "rm ${testingFile}"
     rlPhaseEnd
 
+    if ! rlIsFedora || rlIsFedora ">=45"; then
     rlPhaseStartTest "Checking exit code 3 (added + removed files detected)"
         rlRun "testingFileA=\$(mktemp --tmpdir=$AIDE_TEST_DIR)" 0 "Add file A to watch dir"
         aideInit
@@ -177,6 +178,7 @@ rlJournalStart
 
         rlRun "rm ${testingFileB} ${testingFileC}"
     rlPhaseEnd
+    fi
 
     rlPhaseStartTest "Checking exit code 15 (Invalid argument error)"
         rlRun "aide blahblah" 15

--- a/Sanity/aide-check-sanity/main.fmf
+++ b/Sanity/aide-check-sanity/main.fmf
@@ -3,7 +3,7 @@ contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:
   - aide
-duration: 5m
+duration: 15m
 enabled: true
 tag:
   - fips

--- a/Sanity/aide-check-sanity/runtest.sh
+++ b/Sanity/aide-check-sanity/runtest.sh
@@ -113,7 +113,7 @@ rlJournalStart && {
   rlPhaseEnd; }
 
   # num_workers support: RHEL 9.9+ and 10.3+ only; 10.0-10.2 lack the implementation
-  if { rlIsRHELLike ">=9.9" && ! rlIsRHELLike ">=10"; } || rlIsRHELLike ">=10.3"; then
+  if { rlIsRHELLike ">=9.9" && ! rlIsRHELLike ">=10"; } || rlIsRHELLike ">=10.3" || rlIsFedora ">=45"; then
     rlPhaseStartTest "num_workers set in default /etc/aide.conf" && {
       rlRun "grep -E '^[[:space:]]*num_workers[[:space:]]*=' /etc/aide.conf" 0 \
         "num_workers must be present in /etc/aide.conf"

--- a/Sanity/aide-check-sanity/runtest.sh
+++ b/Sanity/aide-check-sanity/runtest.sh
@@ -112,6 +112,33 @@ rlJournalStart && {
     rm -f $rlRun_LOG
   rlPhaseEnd; }
 
+  # num_workers support: RHEL 9.9+ and 10.3+ only; 10.0-10.2 lack the implementation
+  if { rlIsRHELLike ">=9.9" && ! rlIsRHELLike ">=10"; } || rlIsRHELLike ">=10.3"; then
+    rlPhaseStartTest "num_workers set in default /etc/aide.conf" && {
+      rlRun "grep -E '^[[:space:]]*num_workers[[:space:]]*=' /etc/aide.conf" 0 \
+        "num_workers must be present in /etc/aide.conf"
+      NUM_W=$(grep -E '^[[:space:]]*num_workers[[:space:]]*=' /etc/aide.conf \
+              | awk -F'=' '{print $2}' | tr -d '[:space:]')
+      rlRun "[[ '$NUM_W' -ne 1 ]]" 0 \
+        "num_workers must not be 1 in default config, got: $NUM_W"
+    rlPhaseEnd; }
+
+    rlPhaseStartTest "aide --init with 4 workers is faster than with 1 worker" && {
+      T_START=$(date +%s%3N)
+      rlRun "aide --init -W 1" 0 "aide --init with 1 worker"
+      T1=$(( $(date +%s%3N) - T_START ))
+      rlLog "Time with 1 worker: ${T1} ms"
+
+      T_START=$(date +%s%3N)
+      rlRun "aide --init -W 4" 0 "aide --init with 4 workers"
+      T4=$(( $(date +%s%3N) - T_START ))
+      rlLog "Time with 4 workers: ${T4} ms"
+
+      rlRun "[[ $T4 -lt $T1 ]]" 0 \
+        "4 workers (${T4}ms) must be faster than 1 worker (${T1}ms)"
+    rlPhaseEnd; }
+  fi
+
   [[ -z "$IN_PLACE_UPGRADE" ]] && rlPhaseStartCleanup && {
     rlRun "rlFileRestore"
     rlRun "rm -rf $AIDE_TEST_DIR"

--- a/Sanity/aide-dropin-include-directive/main.fmf
+++ b/Sanity/aide-dropin-include-directive/main.fmf
@@ -16,3 +16,6 @@ adjust:
   - enabled: false
     when: distro >= rhel-10 and distro < rhel-10.3
     continue: false
+  - enabled: false
+    when: distro < fedora-45
+    continue: false

--- a/Sanity/aide-dropin-include-directive/main.fmf
+++ b/Sanity/aide-dropin-include-directive/main.fmf
@@ -1,0 +1,18 @@
+summary: Test aide drop-in include directive and /etc/aide.d properties
+contact: Attila Lakatos <alakatos@redhat.com>
+test: ./runtest.sh
+require+:
+  - aide
+duration: 5m
+enabled: true
+tag:
+  - CI-Tier-1
+  - Tier1
+tier: '1'
+adjust:
+  - enabled: false
+    when: distro < rhel-9.9
+    continue: false
+  - enabled: false
+    when: distro >= rhel-10 and distro < rhel-10.3
+    continue: false

--- a/Sanity/aide-dropin-include-directive/runtest.sh
+++ b/Sanity/aide-dropin-include-directive/runtest.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/aide/Sanity/aide-dropin-include-directive
+#   Description: Test aide drop-in include directive and /etc/aide.d properties
+#   Author: Attila Lakatos <alakatos@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2026 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || :
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="aide"
+DROPIN_CONF="/etc/aide.d/test-dropin.conf"
+WATCH_DIR="/tmp/aide-dropin-test-dir"
+
+rlJournalStart && {
+  rlPhaseStartSetup && {
+    rlAssertRpm $PACKAGE
+    rlRun "rlFileBackup --clean /etc/aide.d"
+    rlRun "rlFileBackup --clean /var/lib/aide"
+    rlRun "mkdir -p $WATCH_DIR"
+    rlRun "echo 'original content' > $WATCH_DIR/testfile"
+  rlPhaseEnd; }
+
+  rlPhaseStartTest "/etc/aide.d directory properties" && {
+    rlAssertExists /etc/aide.d
+    rlRun "test -d /etc/aide.d" 0 "/etc/aide.d must be a directory"
+    rlRun "[[ $(stat -c '%a' /etc/aide.d) == '700' ]]" 0 \
+      "/etc/aide.d must have mode 0700"
+    rlRun "[[ $(stat -c '%U:%G' /etc/aide.d) == 'root:root' ]]" 0 \
+      "/etc/aide.d must be owned by root:root"
+    rlRun "matchpathcon -V /etc/aide.d" 0 \
+      "/etc/aide.d must have the correct SELinux context"
+  rlPhaseEnd; }
+
+  rlPhaseStartTest "/etc/aide.conf contains the @@include directive for /etc/aide.d" && {
+    rlRun "grep -E '@@include[[:space:]]*/etc/aide\.d' /etc/aide.conf" 0 \
+      "/etc/aide.conf must contain an @@include directive for /etc/aide.d"
+    rlRun "grep -E '@@include[[:space:]]*/etc/aide\.d.*\\\.conf' /etc/aide.conf" 0 \
+      "@@include directive must filter for .conf files only"
+  rlPhaseEnd; }
+
+  rlPhaseStartTest "Drop-in .conf file is loaded and its rules take effect" && {
+    rlRun "echo '$WATCH_DIR p+i+n+u+g+s+sha256' > $DROPIN_CONF"
+    rlRun "aide --config-check" 0 \
+      "Config must be valid with the drop-in present"
+    rlRun "aide --init" 0 "Initialize aide database with drop-in rule active"
+    rlRun "mv /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz" 0 \
+      "Promote newly initialized database"
+    rlRun "echo 'modified content' > $WATCH_DIR/testfile"
+    rlRun -s "aide --check" 4 \
+      "aide must detect changes in the drop-in monitored directory"
+    rlAssertGrep "$WATCH_DIR/testfile" $rlRun_LOG
+    rm -f $rlRun_LOG
+  rlPhaseEnd; }
+
+  rlPhaseStartTest "Drop-in .conf file with improper permissions is rejected" && {
+    rlRun "chmod 0666 $DROPIN_CONF" 0 \
+      "Make drop-in world-writable (improper permissions)"
+    rlRun "aide --config-check" 17 \
+      "aide must reject a world-writable drop-in during config check"
+    rlRun "aide --init" 17 \
+      "aide --init must fail when drop-in is world-writable"
+    rlRun "aide --check" 17 \
+      "aide --check must fail when drop-in is world-writable"
+
+    rlRun "chmod 0660 $DROPIN_CONF" 0 \
+      "Make drop-in group-writable (improper permissions)"
+    rlRun "aide --config-check" 17 \
+      "aide must reject a group-writable drop-in during config check"
+    rlRun "aide --init" 17 \
+      "aide --init must fail when drop-in is group-writable"
+    rlRun "aide --check" 17 \
+      "aide --check must fail when drop-in is group-writable"
+
+    rlRun "chmod 0600 $DROPIN_CONF" 0 "Restore proper permissions"
+  rlPhaseEnd; }
+
+  rlPhaseStartTest "Non-.conf files in /etc/aide.d/ are silently ignored" && {
+    rlRun "echo 'THIS IS NOT VALID AIDE CONFIG' > /etc/aide.d/ignore-me.bak"
+    rlRun "aide --config-check" 0 \
+      "aide must not attempt to parse non-.conf files in /etc/aide.d"
+  rlPhaseEnd; }
+
+  rlPhaseStartCleanup && {
+    rlRun "rlFileRestore"
+    rlRun "rm -rf $WATCH_DIR"
+  rlPhaseEnd; }
+
+  rlJournalPrintText
+rlJournalEnd; }

--- a/Sanity/aide-systemd-timer/main.fmf
+++ b/Sanity/aide-systemd-timer/main.fmf
@@ -17,3 +17,6 @@ adjust:
   - enabled: false
     when: distro >= rhel-10 and distro < rhel-10.3
     continue: false
+  - enabled: false
+    when: distro < fedora-45
+    continue: false

--- a/Sanity/aide-systemd-timer/main.fmf
+++ b/Sanity/aide-systemd-timer/main.fmf
@@ -4,7 +4,7 @@ test: ./runtest.sh
 require+:
   - aide
   - systemd
-duration: 10m
+duration: 15m
 enabled: true
 tag:
   - CI-Tier-1

--- a/Sanity/aide-systemd-timer/main.fmf
+++ b/Sanity/aide-systemd-timer/main.fmf
@@ -1,0 +1,19 @@
+summary: Verify aide-check.service and aide-check.timer are shipped and behave correctly
+contact: Attila Lakatos <alakatos@redhat.com>
+test: ./runtest.sh
+require+:
+  - aide
+  - systemd
+duration: 10m
+enabled: true
+tag:
+  - CI-Tier-1
+  - Tier1
+tier: '1'
+adjust:
+  - enabled: false
+    when: distro < rhel-9.9
+    continue: false
+  - enabled: false
+    when: distro >= rhel-10 and distro < rhel-10.3
+    continue: false

--- a/Sanity/aide-systemd-timer/runtest.sh
+++ b/Sanity/aide-systemd-timer/runtest.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/aide/Sanity/aide-systemd-timer
+#   Description: Verify aide-check.service and aide-check.timer are shipped
+#                and behave correctly (RHEL-123520)
+#   Author: Attila Lakatos <alakatos@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2026 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || :
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="aide"
+AIDE_DROPIN="/etc/aide.d/timer-test.conf"
+SERVICE_UNIT="aide-check.service"
+TIMER_UNIT="aide-check.timer"
+AIDE_TEST_DIR="/var/aide-timer-test-dir"
+DB="/var/lib/aide/aide.db.gz"
+DBnew="/var/lib/aide/aide.db.new.gz"
+
+rlJournalStart && {
+  rlPhaseStartSetup && {
+    rlAssertRpm $PACKAGE
+    rlRun "mkdir -p /var/lib/aide"
+    rlRun "rlFileBackup --clean /var/lib/aide"
+    rlRun "rlFileBackup --clean /etc/aide.d"
+    rlRun "mkdir -p $AIDE_TEST_DIR"
+    rlRun "touch $AIDE_TEST_DIR/file1"
+
+    rlRun "echo '$AIDE_TEST_DIR/ p+i+n+u+g+s+sha256' > ${AIDE_DROPIN}" 0 \
+      "Drop test watch rule into /etc/aide.d"
+    rlRun "aide --config-check" 0 "Config must be valid with drop-in present"
+    rlRun "aide --init" 0 "Initialize aide database"
+    rlRun "mv ${DBnew} ${DB}" 0 "Promote database"
+  rlPhaseEnd; }
+
+  rlPhaseStartTest "Unit files are shipped" && {
+    rlRun "systemctl cat $SERVICE_UNIT" 0 "aide-check.service must be known to systemd"
+    rlRun "systemctl cat $TIMER_UNIT" 0 "aide-check.timer must be known to systemd"
+  rlPhaseEnd; }
+
+  rlPhaseStartTest "Timer is disabled by default" && {
+    ENABLED=$(systemctl is-enabled $TIMER_UNIT 2>/dev/null)
+    rlRun "[[ '$ENABLED' == 'disabled' ]]" 0 \
+      "aide-check.timer must be disabled by default, got: $ENABLED"
+    STATE=$(systemctl show $TIMER_UNIT --property=ActiveState --value 2>/dev/null)
+    rlRun "[[ '$STATE' == 'inactive' ]]" 0 \
+      "aide-check.timer ActiveState must be 'inactive' by default, got: $STATE"
+  rlPhaseEnd; }
+
+  rlPhaseStartTest "Service unit has required directives" && {
+    rlRun -s "systemctl cat $SERVICE_UNIT" 0 "Read effective service unit"
+    rlAssertGrep "Type=oneshot" $rlRun_LOG
+    rlAssertGrep "ExecStart=.*aide.*--check" $rlRun_LOG -E
+    rlAssertGrep "SuccessExitStatus=" $rlRun_LOG
+    rlAssertGrep "Nice=19" $rlRun_LOG
+    rlAssertGrep "IOSchedulingClass=idle" $rlRun_LOG
+    rm -f $rlRun_LOG
+  rlPhaseEnd; }
+
+  rlPhaseStartTest "Timer unit has required scheduling directives" && {
+    rlRun -s "systemctl cat $TIMER_UNIT" 0 "Read effective timer unit"
+    rlAssertGrep "OnCalendar=daily" $rlRun_LOG
+    rlAssertGrep "Persistent=true" $rlRun_LOG
+    rlAssertGrep "WantedBy=timers.target" $rlRun_LOG
+    rm -f $rlRun_LOG
+  rlPhaseEnd; }
+
+  rlPhaseStartTest "Service succeeds when aide detects changes" && {
+    # Modify a tracked file so aide --check exits with a non-zero code.
+    # Without SuccessExitStatus= covering aide's result codes, systemd would
+    # mark the service as failed even though aide ran correctly.
+    rlRun "echo 'changed' > $AIDE_TEST_DIR/file1" 0 \
+      "Modify tracked file to trigger a non-zero aide exit code"
+
+    rlRun "systemctl daemon-reload" 0
+    rlRun "systemctl start aide-check.service" 0 \
+      "Starting the service must succeed even when aide detects changes"
+
+    RESULT=$(systemctl show aide-check.service --property=Result --value)
+    rlRun "[[ '$RESULT' == 'success' ]]" 0 \
+      "Service Result must be 'success' when aide detects changes, got: $RESULT"
+  rlPhaseEnd; }
+
+  rlPhaseStartCleanup && {
+    rlRun "systemctl disable --now $TIMER_UNIT" 0,1 \
+      "Disable timer (idempotent if never enabled)"
+    rlRun "systemctl reset-failed $SERVICE_UNIT" 0,1
+    rlRun "systemctl daemon-reload"
+    rlRun "rlFileRestore"
+    rlRun "rm -rf $AIDE_TEST_DIR"
+  rlPhaseEnd; }
+
+  rlJournalPrintText
+rlJournalEnd; }

--- a/Sanity/aide-systemd-timer/runtest.sh
+++ b/Sanity/aide-systemd-timer/runtest.sh
@@ -103,6 +103,23 @@ rlJournalStart && {
       "Service Result must be 'success' when aide detects changes, got: $RESULT"
   rlPhaseEnd; }
 
+  rlPhaseStartTest "Timer fires and triggers aide-check.service" && {
+    rlRun "printf '[Timer]\nOnCalendar=\nOnCalendar=minutely\nAccuracySec=1s\n' \
+      | systemctl edit --stdin --drop-in=ci-test-override.conf $TIMER_UNIT" 0 \
+      "Install minutely OnCalendar drop-in (daemon-reload done automatically)"
+    BEFORE=$(date '+%s')
+    rlRun "systemctl enable --now $TIMER_UNIT" 0 "Enable and start the timer"
+    rlLog "Waiting 90s for timer to fire at the next minute boundary"
+    sleep 90
+    rlRun -s "journalctl -u $SERVICE_UNIT --since @${BEFORE} --no-pager" 0 \
+      "Collect journal entries since timer was enabled"
+    rlAssertGrep "aide-check.service" $rlRun_LOG
+    rm -f $rlRun_LOG
+    rlRun "systemctl disable --now $TIMER_UNIT" 0 "Disable timer after check"
+    rlRun "systemctl revert $TIMER_UNIT" 0 \
+      "Remove drop-in and restore unit to package defaults"
+  rlPhaseEnd; }
+
   rlPhaseStartCleanup && {
     rlRun "systemctl disable --now $TIMER_UNIT" 0,1 \
       "Disable timer (idempotent if never enabled)"


### PR DESCRIPTION
Adds four test changes:

- **aide-check-sanity**: regression tests for `num_workers` (RHEL-178123) — verifies the directive is present in the default config and that 4 workers complete faster than 1.

- **aide-dropin-include-directive**: new Sanity test for the `/etc/aide.d` drop-in include feature — checks directory properties, the `@@include` directive in `aide.conf`, that drop-in `.conf` files are loaded and applied, and that files with wrong permissions or non-`.conf` extensions are handled correctly. Gated to RHEL 9.9+ / 10.3+.

- **aide-check-exit-codes**: adds the four missing bitmask combinations — exit codes 3, 5, 6, and 7 (added+removed, added+changed, removed+changed, all three) — to the existing exit code test.

- **aide-systemd-timer**: new Sanity test for the `aide-check.service` and `aide-check.timer` units shipped by RHEL-123520 — checks that the units are known to systemd, the timer is disabled by default, the service has `SuccessExitStatus=` / `CPUQuota=` / `IOSchedulingClass=idle`, and that the service reports `Result=success` when aide exits non-zero after detecting changes. Gated to RHEL 9.9+ / 10.3+.

## Summary by Sourcery

Extend AIDE sanity coverage for configuration drop-ins, systemd timer behavior, and exit code handling.

Tests:
- Add coverage for AIDE exit code combinations 3, 5, 6, and 7 when files are added, removed, and changed.
- Add sanity checks that the num_workers directive is present in the default configuration and that multi-worker initialization outperforms single-worker runs on supported RHEL versions.
- Introduce a sanity test verifying /etc/aide.d properties, inclusion from aide.conf, handling of drop-in .conf files, and rejection/ignoring of improperly permissioned or non-.conf files.
- Introduce a sanity test ensuring aide-check.service and aide-check.timer units are shipped with the correct defaults, directives, and behavior when AIDE reports changes.