### PR TITLE
Adjust aide tests for version-dependent output format

### DIFF
--- a/Sanity/aide-check-sanity/runtest.sh
+++ b/Sanity/aide-check-sanity/runtest.sh
@@ -92,7 +92,7 @@ rlJournalStart && {
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file2;SHA256_old=O7Krtp67J/v+Y8djliTG7F4zG4QaW8jD68ELkoXpCHc=;SHA256_new=wM3nf6j++X1HbBCq09LVT8wvM2FA0HNlHC3Mzx43n9Y=" $rlRun_LOG
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file3;Perm_old=-rw-rw-rw-;Perm_new=-rwxrwxrwx" $rlRun_LOG
       rlAssertGrep "file=$AIDE_TEST_DIR/data/file4; added" $rlRun_LOG
-    elif rlIsFedora ">41" || rlIsRHELLike '>=9.8'; then
+    elif rlIsFedora ">41" || rpm -q aide | grep -q 'aide-0\.19'; then
       rlAssertGrep "f-----------------: /var/aide-testing-dir/data/file1" $rlRun_LOG
       rlAssertGrep "File: $AIDE_TEST_DIR/data/file2\n
  SHA256    : O7Krtp67J/v+Y8djliTG7F4zG4QaW8jD | wM3nf6j++X1HbBCq09LVT8wvM2FA0HNl\n

--- a/Sanity/aide-migrate-config/main.fmf
+++ b/Sanity/aide-migrate-config/main.fmf
@@ -26,10 +26,10 @@ link:
   - verifies: https://issues.redhat.com/browse/RHEL-83776
 adjust:
   - enabled: false
-    when: distro < rhel-9.9
+    when: distro < rhel-9.8
     because: aide-migrate-config is available from this version
   - enabled: false
-    when: distro < rhel-10.3 and distro >= rhel-10
+    when: distro < rhel-10.2 and distro >= rhel-10
     because: aide-migrate-config is available from this version
   - enabled: false
     when: distro == fedora


### PR DESCRIPTION
Enable aide migration script condition for older releases. Use rpm version check instead of distro version to determine aide check output format, since aide 0.19 can ship on different RHEL versions (9.8+, 10.2+).

## Summary by Sourcery

Adjust aide-related tests to handle version-dependent output formats and enable migration checks on older releases.

Tests:
- Update aide check sanity test to select the expected output format based on the installed aide package version instead of the OS version.
- Enable aide migration configuration testing for older releases that ship the newer aide version.