### PR TITLE
Fix aide-running-as-user for @@include permission checks

### DIFF
--- a/Sanity/aide-running-as-user/runtest.sh
+++ b/Sanity/aide-running-as-user/runtest.sh
@@ -48,12 +48,13 @@ rlJournalStart
         rlRun "chmod -R a=rwx $TEST_DIR/" 0 "Adding permissions for testing directory"
         rlRun "sed -i 's|@@define DBDIR .*|@@define DBDIR $TEST_DIR/db|' $TEST_DIR/aide.conf" 0
         rlRun "sed -i 's|@@define LOGDIR .*|@@define LOGDIR $TEST_DIR/log|' $TEST_DIR/aide.conf" 0
+        rlRun "testUserSetup"
         # Redirect @@include to a user-accessible directory (aide.d is 0700 root:root since RHEL-9.9/10.3)
         if rlIsRHELLike ">=9.9" || rlIsRHELLike ">=10.3"; then
-            rlRun "mkdir -p -m0777 $TEST_DIR/aide.d"
+            rlRun "mkdir -p -m0700 $TEST_DIR/aide.d"
+            rlRun "chown $testUser $TEST_DIR/aide.d"
             rlRun "sed -i 's|/etc/aide\.d|${TEST_DIR}/aide.d|' $TEST_DIR/aide.conf" 0
         fi
-        rlRun "testUserSetup"
         rlRun "echo 'Random text' > $TEST_DIR/data/random.txt"
         rlRun "chmod a=r $TEST_DIR/data/random.txt"
         echo 'int main(void) { return 0; }' > $TEST_DIR/main.c


### PR DESCRIPTION
The @@include permission check patch (aide-include-permission-checks) now rejects world-writable directories. Set aide.d to 0700 owned by testUser instead of 0777, and move testUserSetup before the directory creation so testUser variable is available.

## Summary by Sourcery

Adjust aide-running-as-user test setup to comply with updated @@include permission checks rejecting world-writable directories.

Tests:
- Change aide.d test directory permissions from world-writable to 0700 and ensure it is owned by the test user.
- Reorder test setup so the test user is created before using it to configure the aide.d directory.