### PR TITLE
Wait for boot services before aide --init in post-reboot phase

### DIFF
--- a/Regression/rhel-83776_aide-conf-journal-issue/runtest.sh
+++ b/Regression/rhel-83776_aide-conf-journal-issue/runtest.sh
@@ -66,6 +66,7 @@ rlJournalStart
         rlPhaseStartTest "Check issue after reboot and journalctl rotate"
             pushd $AIDE_TEST_DIR
             rlRun "rm $COOKIE"
+            rlRun "systemctl is-system-running --wait" 0-1 "Wait for system to fully boot"
             rlRun "aide --config=aide.conf --init"
             rlRun "journalctl --rotate"
             rlRun "mv /var/aide-testing-dir/aide.db.new.gz /var/aide-testing-dir/aide.db.gz"


### PR DESCRIPTION
After reboot, services like kdump may still be rebuilding initramfs when the test starts. This causes aide --check to detect changes in /boot that happened between --init and --check. Wait for systemd to report the system as fully booted before capturing the AIDE database.

## Summary by Sourcery

Bug Fixes:
- Prevent AIDE from capturing its baseline while boot services are still modifying /boot by waiting for systemd to report the system as fully booted.