### PR TITLE
[AUTO] RHEL-141678 - aide multi-threading performance regression

### DIFF
--- a/Regression/RHEL-141678-aide-threading-performance/PURPOSE
+++ b/Regression/RHEL-141678-aide-threading-performance/PURPOSE
@@ -1,0 +1,4 @@
+PURPOSE of /CoreOS/aide/Regression/RHEL-141678-aide-threading-performance
+Description: This test verifies that the default multi-threading in AIDE does not cause a significant performance regression during database initialization, as reported in RHEL-141678.
+Author: QE Automation <sec-eng-special@redhat.com>
+Bug: https://issues.redhat.com/browse/RHEL-141678

--- a/Regression/RHEL-141678-aide-threading-performance/main.fmf
+++ b/Regression/RHEL-141678-aide-threading-performance/main.fmf
@@ -1,0 +1,22 @@
+summary: Test for RHEL-141678 - aide multi-threading performance regression
+description: |
+    Bug: https://issues.redhat.com/browse/RHEL-141678
+    This test verifies that the default multi-threading in AIDE does not
+    cause a significant performance regression during database initialization.
+    It measures the execution time of `aide --init` with and without the `-W 0`
+    option and asserts that the multi-threaded run is not significantly
+    slower than the single-threaded run.
+contact: QE Automation <sec-eng-special@redhat.com>
+test: ./runtest.sh
+framework: beakerlib
+recommend:
+    - aide
+duration: 10m
+tag:
+    - Tier1
+    - Tier1security
+    - Regression
+adjust:
+    - enabled: false
+      when: distro < rhel-10.3
+      continue: false

--- a/Regression/RHEL-141678-aide-threading-performance/runtest.sh
+++ b/Regression/RHEL-141678-aide-threading-performance/runtest.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup "Setup"
+        rlAssertRpm "aide"
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd \$TmpDir"
+        rlRun "cp /etc/aide.conf ."
+        rlRun "sed -i 's|^database=.*|database=file:aide.db.gz|' aide.conf"
+        rlRun "sed -i 's|^database_out=.*|database_out=file:aide.db.new.gz|' aide.conf"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test AIDE performance with and without multi-threading"
+        # Time the execution of "aide --init" with default multi-threading
+        rlRun "SECONDS=0; aide --init -c aide.conf; multithread_time=\$SECONDS" "Running aide --init with multi-threading"
+        rlLog "Multi-threaded execution time: \$multithread_time seconds"
+        rlRun "rm -f aide.db.new.gz"
+
+        # Time the execution of "aide --init" with multi-threading disabled
+        rlRun "SECONDS=0; aide --init -c aide.conf -W 0; singlethread_time=\$SECONDS" "Running aide --init without multi-threading"
+        rlLog "Single-threaded execution time: \$singlethread_time seconds"
+
+        # Compare the execution times. Allow for a 20% tolerance.
+        # The single-threaded time should be less than or equal to the multi-threaded time plus the tolerance.
+        # In other words, the multi-threaded time should not be more than 20% slower than the single-threaded time.
+        #
+        # The bug report shows the multi-threaded version is slower, so we are checking that the fix
+        # makes the multi-threaded version not significantly slower.
+        #
+        # Test should fail if: singlethread_time * 1.2 < multithread_time
+        # Test should pass if: singlethread_time * 1.2 >= multithread_time
+        #
+        # Using integer arithmetic for the comparison.
+        # We are checking if (singlethread_time * 120) / 100 < multithread_time
+        allowed_time=\$((singlethread_time * 120 / 100))
+        rlLog "Allowed time for multi-threaded execution (20% tolerance): \$allowed_time seconds"
+
+        if [ "\$multithread_time" -gt "\$allowed_time" ]; then
+            rlFail "AIDE with multi-threading is more than 20% slower than without."
+        else
+            rlPass "AIDE with multi-threading is not significantly slower than without."
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartCleanup "Cleanup"
+        rlRun "popd"
+        rlRun "rm -rf \$TmpDir" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd


### PR DESCRIPTION
This PR was generated by the QE automation pipeline and requires human review.

### Summary
This PR introduces a new regression test for [RHEL-141678](https://issues.redhat.com/browse/RHEL-141678), which addresses a performance degradation in `aide` when using its default multi-threading capabilities.

### Test Description
The new test, located at `Regression/RHEL-141678-aide-threading-performance`, measures and compares the execution time of `aide --init` with and without multi-threading enabled (`-W 0` flag).

The test fails if the multi-threaded execution is more than 20% slower than the single-threaded execution, thus preventing future performance regressions of this nature.

### How to Run
1. Provision a RHEL 10.3 or later machine.
2. Install `aide` and `beakerlib`.
3. Execute the test using `rhts-run.sh` or `tmt`.

### Reference Tests
- `Sanity/aide-db-update-and-compare`

## Summary by Sourcery

Tests:
- Introduce a beakerlib-based regression test that compares aide --init execution time with and without multi-threading and fails if multi-threading is over 20% slower.