### PR TITLE
Add missing descriptions to main.fmf test cases

### DIFF
--- a/Image-mode/init-during-bootc-update/main.fmf
+++ b/Image-mode/init-during-bootc-update/main.fmf
@@ -1,6 +1,8 @@
 summary: Aide init during bootc build
-description: Init aide during container bootc build. Scenario check if aide work during
-    build mode and if runtime instance of aide is affected after update.
+description: |
+    Init aide during container bootc build. Scenario check if aide work
+    during build mode and if runtime instance of aide is affected after
+    update.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - aide

--- a/Regression/Check-no-weird-lines-in-etc-aide-conf/main.fmf
+++ b/Regression/Check-no-weird-lines-in-etc-aide-conf/main.fmf
@@ -1,5 +1,8 @@
 summary: Check no weird lines in /etc/aide.conf
-description: Verify that /etc/aide.conf does not contain deprecated, duplicate, or invalid path entries and that all configured paths correspond to files provided by installed packages.
+description: |
+    Verify that /etc/aide.conf does not contain deprecated, duplicate, or
+    invalid path entries and that all configured paths correspond to files
+    provided by installed packages.
 contact: Martin Zelený <mzeleny@redhat.com>
 component:
   - aide

--- a/Regression/Check-no-weird-lines-in-etc-aide-conf/main.fmf
+++ b/Regression/Check-no-weird-lines-in-etc-aide-conf/main.fmf
@@ -1,5 +1,5 @@
 summary: Check no weird lines in /etc/aide.conf
-description: ''
+description: Verify that /etc/aide.conf does not contain deprecated, duplicate, or invalid path entries and that all configured paths correspond to files provided by installed packages.
 contact: Martin Zelený <mzeleny@redhat.com>
 component:
   - aide

--- a/Regression/rhel-118491_lower_alpha_string_cant_be_used/main.fmf
+++ b/Regression/rhel-118491_lower_alpha_string_cant_be_used/main.fmf
@@ -1,5 +1,5 @@
 summary: Scenario to check that lower alpha string can be used in AIDE configuration
-description: ''
+description: Verify that aide accepts lowercase alphabetic strings as custom group names in configuration and correctly initializes and checks the database using them.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - aide

--- a/Regression/rhel-118491_lower_alpha_string_cant_be_used/main.fmf
+++ b/Regression/rhel-118491_lower_alpha_string_cant_be_used/main.fmf
@@ -1,5 +1,8 @@
 summary: Scenario to check that lower alpha string can be used in AIDE configuration
-description: Verify that aide accepts lowercase alphabetic strings as custom group names in configuration and correctly initializes and checks the database using them.
+description: |
+    Verify that aide accepts lowercase alphabetic strings as custom group
+    names in configuration and correctly initializes and checks the
+    database using them.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - aide

--- a/Regression/rhel-1382_rhel-59170/main.fmf
+++ b/Regression/rhel-1382_rhel-59170/main.fmf
@@ -1,5 +1,8 @@
 summary: RHEL-1382 and RHEL-59170 regression test
-description: Verify that aide --init correctly measures files without producing gnutls hash warnings for unsupported algorithms and that the resulting database is not empty.
+description: |
+    Verify that aide --init correctly measures files without producing
+    gnutls hash warnings for unsupported algorithms and that the resulting
+    database is not empty.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - aide

--- a/Regression/rhel-1382_rhel-59170/main.fmf
+++ b/Regression/rhel-1382_rhel-59170/main.fmf
@@ -1,5 +1,5 @@
 summary: RHEL-1382 and RHEL-59170 regression test
-description: ''
+description: Verify that aide --init correctly measures files without producing gnutls hash warnings for unsupported algorithms and that the resulting database is not empty.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - aide

--- a/Regression/rhel-1569-aide-sigbus-on-truncate/main.fmf
+++ b/Regression/rhel-1569-aide-sigbus-on-truncate/main.fmf
@@ -1,5 +1,7 @@
 summary: aide detects SIGBUS but dont exit when a file gets truncated
-description: Verify that aide handles file truncation during a scan gracefully without crashing with SIGBUS or SIGSEGV.
+description: |
+    Verify that aide handles file truncation during a scan gracefully
+    without crashing with SIGBUS or SIGSEGV.
 contact: Patrik Koncity <pkoncity@redhat.com>
 test: ./runtest.sh
 require:

--- a/Regression/rhel-1569-aide-sigbus-on-truncate/main.fmf
+++ b/Regression/rhel-1569-aide-sigbus-on-truncate/main.fmf
@@ -1,5 +1,5 @@
 summary: aide detects SIGBUS but dont exit when a file gets truncated
-description: ''
+description: Verify that aide handles file truncation during a scan gracefully without crashing with SIGBUS or SIGSEGV.
 contact: Patrik Koncity <pkoncity@redhat.com>
 test: ./runtest.sh
 require:

--- a/Regression/rhel-76014-http-link-as-database/main.fmf
+++ b/Regression/rhel-76014-http-link-as-database/main.fmf
@@ -1,5 +1,8 @@
 summary: Test for RHEL-76014 (Aide crash when it's used http link as database)
-description: Verify that aide does not crash when an HTTPS URL is used as the database source by starting a local HTTPS server and running aide --check against it.
+description: |
+    Verify that aide does not crash when an HTTPS URL is used as the
+    database source by starting a local HTTPS server and running aide
+    --check against it.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - aide

--- a/Regression/rhel-76014-http-link-as-database/main.fmf
+++ b/Regression/rhel-76014-http-link-as-database/main.fmf
@@ -1,5 +1,5 @@
 summary: Test for RHEL-76014 (Aide crash when it's used http link as database)
-description: |
+description: Verify that aide does not crash when an HTTPS URL is used as the database source by starting a local HTTPS server and running aide --check against it.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - aide

--- a/Regression/rhel-83776_aide-conf-journal-issue/main.fmf
+++ b/Regression/rhel-83776_aide-conf-journal-issue/main.fmf
@@ -1,5 +1,8 @@
 summary: Check that aide databse don't contain journal logs
-description: Verify that aide database does not include journal log or logrotate entries that would cause false positive integrity change reports after reboot or journal rotation.
+description: |
+    Verify that aide database does not include journal log or logrotate
+    entries that would cause false positive integrity change reports after
+    reboot or journal rotation.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - aide

--- a/Regression/rhel-83776_aide-conf-journal-issue/main.fmf
+++ b/Regression/rhel-83776_aide-conf-journal-issue/main.fmf
@@ -1,5 +1,5 @@
 summary: Check that aide databse don't contain journal logs
-description: ''
+description: Verify that aide database does not include journal log or logrotate entries that would cause false positive integrity change reports after reboot or journal rotation.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - aide

--- a/Regression/rhel4331-grubenv-timestaps-break-aide-integrity-check/main.fmf
+++ b/Regression/rhel4331-grubenv-timestaps-break-aide-integrity-check/main.fmf
@@ -1,6 +1,6 @@
 summary: Check /boot/grub2/grubenv's timestamp modification doesn't break aide integrity
     check
-description: ''
+description: Verify that grub-boot-success.service modifying /boot/grub2/grubenv does not cause aide integrity check failures.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - aide

--- a/Regression/rhel4331-grubenv-timestaps-break-aide-integrity-check/main.fmf
+++ b/Regression/rhel4331-grubenv-timestaps-break-aide-integrity-check/main.fmf
@@ -1,6 +1,8 @@
 summary: Check /boot/grub2/grubenv's timestamp modification doesn't break aide integrity
     check
-description: Verify that grub-boot-success.service modifying /boot/grub2/grubenv does not cause aide integrity check failures.
+description: |
+    Verify that grub-boot-success.service modifying /boot/grub2/grubenv
+    does not cause aide integrity check failures.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - aide

--- a/Sanity/aide-check-exit-codes/main.fmf
+++ b/Sanity/aide-check-exit-codes/main.fmf
@@ -1,5 +1,8 @@
 summary: Check all possible exit codes according to the test coverage.
-description: Verify that aide returns correct bitmask exit codes for all change types including added, removed, changed files and their combinations, as well as error codes for invalid arguments and IO errors.
+description: |
+    Verify that aide returns correct bitmask exit codes for all change
+    types including added, removed, changed files and their combinations,
+    as well as error codes for invalid arguments and IO errors.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/aide-check-exit-codes/main.fmf
+++ b/Sanity/aide-check-exit-codes/main.fmf
@@ -1,5 +1,5 @@
 summary: Check all possible exit codes according to the test coverage.
-description: ''
+description: Verify that aide returns correct bitmask exit codes for all change types including added, removed, changed files and their combinations, as well as error codes for invalid arguments and IO errors.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/aide-check-sanity/main.fmf
+++ b/Sanity/aide-check-sanity/main.fmf
@@ -1,4 +1,5 @@
-description: basic check sanity
+description: |
+    basic check sanity
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/aide-conf-group-definition/main.fmf
+++ b/Sanity/aide-conf-group-definition/main.fmf
@@ -1,5 +1,8 @@
 summary: Test custom aide groups of what should be checked
-description: Verify that custom group definitions in aide.conf correctly control which attributes are reported on file changes, ensuring each group only monitors the specified properties.
+description: |
+    Verify that custom group definitions in aide.conf correctly control
+    which attributes are reported on file changes, ensuring each group
+    only monitors the specified properties.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/aide-conf-group-definition/main.fmf
+++ b/Sanity/aide-conf-group-definition/main.fmf
@@ -1,5 +1,5 @@
 summary: Test custom aide groups of what should be checked
-description: ''
+description: Verify that custom group definitions in aide.conf correctly control which attributes are reported on file changes, ensuring each group only monitors the specified properties.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/aide-conf-selection-lines/main.fmf
+++ b/Sanity/aide-conf-selection-lines/main.fmf
@@ -1,5 +1,8 @@
 summary: Check the proper file verficaton accroding to the selectors in aide.conf
-description: Verify that aide selection line selectors work correctly - regular '/' paths track files, '!' negation excludes directories, and '=' equals selector monitors only the directory itself without recursion.
+description: |
+    Verify that aide selection line selectors work correctly - regular '/'
+    paths track files, '!' negation excludes directories, and '=' equals
+    selector monitors only the directory itself without recursion.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/aide-conf-selection-lines/main.fmf
+++ b/Sanity/aide-conf-selection-lines/main.fmf
@@ -1,5 +1,5 @@
 summary: Check the proper file verficaton accroding to the selectors in aide.conf
-description: ''
+description: Verify that aide selection line selectors work correctly - regular '/' paths track files, '!' negation excludes directories, and '=' equals selector monitors only the directory itself without recursion.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/aide-config-check-command/main.fmf
+++ b/Sanity/aide-config-check-command/main.fmf
@@ -1,5 +1,8 @@
 summary: tests aide --config-check command
-description: Verify that aide --config-check validates the default configuration successfully, reports syntax errors for faulty config files, and handles non-existing config file paths gracefully.
+description: |
+    Verify that aide --config-check validates the default configuration
+    successfully, reports syntax errors for faulty config files, and
+    handles non-existing config file paths gracefully.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/aide-config-check-command/main.fmf
+++ b/Sanity/aide-config-check-command/main.fmf
@@ -1,5 +1,5 @@
 summary: tests aide --config-check command
-description: ''
+description: Verify that aide --config-check validates the default configuration successfully, reports syntax errors for faulty config files, and handles non-existing config file paths gracefully.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/aide-db-update-and-compare/main.fmf
+++ b/Sanity/aide-db-update-and-compare/main.fmf
@@ -1,5 +1,5 @@
 summary: tests --update and --compare aide commands
-description: ''
+description: Verify that aide --update detects newly added files and produces an updated database, and that aide --compare correctly identifies differences between two database versions.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/aide-db-update-and-compare/main.fmf
+++ b/Sanity/aide-db-update-and-compare/main.fmf
@@ -1,5 +1,8 @@
 summary: tests --update and --compare aide commands
-description: Verify that aide --update detects newly added files and produces an updated database, and that aide --compare correctly identifies differences between two database versions.
+description: |
+    Verify that aide --update detects newly added files and produces an
+    updated database, and that aide --compare correctly identifies
+    differences between two database versions.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/aide-dropin-include-directive/main.fmf
+++ b/Sanity/aide-dropin-include-directive/main.fmf
@@ -1,4 +1,5 @@
 summary: Test aide drop-in include directive and /etc/aide.d properties
+description: Verify that /etc/aide.d directory has correct permissions and ownership, that drop-in .conf files are loaded and their rules take effect, that improperly permissioned drop-ins are rejected, and that non-.conf files are silently ignored.
 contact: Attila Lakatos <alakatos@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/aide-dropin-include-directive/main.fmf
+++ b/Sanity/aide-dropin-include-directive/main.fmf
@@ -1,5 +1,9 @@
 summary: Test aide drop-in include directive and /etc/aide.d properties
-description: Verify that /etc/aide.d directory has correct permissions and ownership, that drop-in .conf files are loaded and their rules take effect, that improperly permissioned drop-ins are rejected, and that non-.conf files are silently ignored.
+description: |
+    Verify that /etc/aide.d directory has correct permissions and
+    ownership, that drop-in .conf files are loaded and their rules take
+    effect, that improperly permissioned drop-ins are rejected, and that
+    non-.conf files are silently ignored.
 contact: Attila Lakatos <alakatos@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/aide-rules-test/main.fmf
+++ b/Sanity/aide-rules-test/main.fmf
@@ -1,5 +1,9 @@
 summary: Tests if aide properly handles default rules
-description: Verify that aide correctly detects changes to file attributes covered by default rules including permissions, size, checksums, ACLs, SELinux contexts, xattrs, and e2fsattrs, and accurately reports added, removed, and changed entries.
+description: |
+    Verify that aide correctly detects changes to file attributes covered
+    by default rules including permissions, size, checksums, ACLs, SELinux
+    contexts, xattrs, and e2fsattrs, and accurately reports added,
+    removed, and changed entries.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/aide-rules-test/main.fmf
+++ b/Sanity/aide-rules-test/main.fmf
@@ -1,5 +1,5 @@
 summary: Tests if aide properly handles default rules
-description: ''
+description: Verify that aide correctly detects changes to file attributes covered by default rules including permissions, size, checksums, ACLs, SELinux contexts, xattrs, and e2fsattrs, and accurately reports added, removed, and changed entries.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/aide-running-as-user/main.fmf
+++ b/Sanity/aide-running-as-user/main.fmf
@@ -1,5 +1,8 @@
 summary: tests aide --config-check command
-description: Verify that aide can be executed as a non-root user to initialize, check, and update the database, correctly detecting new files, permission changes, and content modifications.
+description: |
+    Verify that aide can be executed as a non-root user to initialize,
+    check, and update the database, correctly detecting new files,
+    permission changes, and content modifications.
 contact: Marek Šafařík <msafarik@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/aide-running-as-user/main.fmf
+++ b/Sanity/aide-running-as-user/main.fmf
@@ -1,5 +1,5 @@
 summary: tests aide --config-check command
-description: ''
+description: Verify that aide can be executed as a non-root user to initialize, check, and update the database, correctly detecting new files, permission changes, and content modifications.
 contact: Marek Šafařík <msafarik@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/aide-systemd-timer/main.fmf
+++ b/Sanity/aide-systemd-timer/main.fmf
@@ -1,5 +1,9 @@
 summary: Verify aide-check.service and aide-check.timer are shipped and behave correctly
-description: Verify that aide-check.service and aide-check.timer unit files are shipped, the timer is disabled by default, the service has correct directives and handles non-zero aide exit codes as success, and the timer correctly triggers periodic aide checks.
+description: |
+    Verify that aide-check.service and aide-check.timer unit files are
+    shipped, the timer is disabled by default, the service has correct
+    directives and handles non-zero aide exit codes as success, and the
+    timer correctly triggers periodic aide checks.
 contact: Attila Lakatos <alakatos@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/aide-systemd-timer/main.fmf
+++ b/Sanity/aide-systemd-timer/main.fmf
@@ -1,4 +1,5 @@
 summary: Verify aide-check.service and aide-check.timer are shipped and behave correctly
+description: Verify that aide-check.service and aide-check.timer unit files are shipped, the timer is disabled by default, the service has correct directives and handles non-zero aide exit codes as success, and the timer correctly triggers periodic aide checks.
 contact: Attila Lakatos <alakatos@redhat.com>
 test: ./runtest.sh
 require+:


### PR DESCRIPTION
Add descriptions to test cases that had empty or missing description field in main.fmf.

## Summary by Sourcery

Add missing descriptions to aide-related test cases in main.fmf metadata files across regression and sanity suites.

Documentation:
- Document previously undocumented regression tests for various aide configuration and behavior issues in main.fmf.
- Add descriptions to sanity aide test cases to clarify their purpose and coverage in the test metadata.